### PR TITLE
fix golibmc

### DIFF
--- a/memd_test.go
+++ b/memd_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/douban/libmc/golibmc"
+	golibmc "github.com/douban/libmc/src"
 	"github.com/ugorji/go/codec"
 )
 


### PR DESCRIPTION
- when I use this library and run `go mod tidy`,  I got an error:
```
        github.com/jkatagi/memd tested by
        github.com/jkatagi/memd.test imports
        github.com/douban/libmc/golibmc: module github.com/douban/libmc@latest found (v1.4.1), but does not contain package github.com/douban/libmc/golibmc
```
- so I fix the path